### PR TITLE
Making the classes exposed in the framework public

### DIFF
--- a/LocalMeasureWidgetKit/ImageMeta.swift
+++ b/LocalMeasureWidgetKit/ImageMeta.swift
@@ -8,14 +8,14 @@
 
 import ObjectMapper
 
-class LMImageMeta: Mappable {
-    var url: String?
-    var width: Int?
-    var height: Int?
+public class LMImageMeta: Mappable {
+    public var url: String?
+    public var width: Int?
+    public var height: Int?
     
-    required init?(_ map: Map) {}
+    public required init?(_ map: Map) {}
     
-    func mapping(map: Map) {
+    public func mapping(map: Map) {
         url    <- map["url"]
         width  <- map["width"]
         height <- map["height"]

--- a/LocalMeasureWidgetKit/LMImageSize.swift
+++ b/LocalMeasureWidgetKit/LMImageSize.swift
@@ -8,13 +8,13 @@
 
 import ObjectMapper
 
-class LMImageSize: Mappable {
-    var width: Int?
-    var height: Int?
+public class LMImageSize: Mappable {
+    public var width: Int?
+    public var height: Int?
     
-    required init?(_ map: Map) {}
+    public required init?(_ map: Map) {}
     
-    func mapping(map: Map) {
+    public func mapping(map: Map) {
         width  <- map["width"]
         height <- map["height"]
     }

--- a/LocalMeasureWidgetKit/LMLocation.swift
+++ b/LocalMeasureWidgetKit/LMLocation.swift
@@ -8,15 +8,15 @@
 
 import ObjectMapper
 
-class LMLocation: Mappable {
-    var latitude: Float?
-    var longitude: Float?
-    var address: String?
-    var name: String?
+public class LMLocation: Mappable {
+    public var latitude: Float?
+    public var longitude: Float?
+    public var address: String?
+    public var name: String?
     
-    required init?(_ map: Map) {}
+    required public init?(_ map: Map) {}
     
-    func mapping(map: Map) {
+    public func mapping(map: Map) {
         latitude  <- map["latitude"]
         longitude <- map["longitude"]
         address   <- map["address"]

--- a/LocalMeasureWidgetKit/LMPost.swift
+++ b/LocalMeasureWidgetKit/LMPost.swift
@@ -8,22 +8,22 @@
 
 import ObjectMapper
 
-class LMPost: Mappable {
-    var rating: Int?
-    var text: String?
-    var image: String?
-    var video: String?
-    var imageSize: LMImageSize?
-    var images: [LMImageMeta]?
-    var kind: String?
-    var created: String?
-    var source: LMSource?
-    var poster: LMPoster?
-    var link: String?
+public class LMPost: Mappable {
+    public var rating: Int?
+    public var text: String?
+    public var image: String?
+    public var video: String?
+    public var imageSize: LMImageSize?
+    public var images: [LMImageMeta]?
+    public var kind: String?
+    public var created: String?
+    public var source: LMSource?
+    public var poster: LMPoster?
+    public var link: String?
     
-    required init?(_ map: Map) {}
+    public required init?(_ map: Map) {}
     
-    func mapping(map: Map) {
+    public func mapping(map: Map) {
         rating    <- map["rating"]
         text      <- map["text"]
         image     <- map["image"]

--- a/LocalMeasureWidgetKit/LMPoster.swift
+++ b/LocalMeasureWidgetKit/LMPoster.swift
@@ -8,14 +8,14 @@
 
 import ObjectMapper
 
-class LMPoster: Mappable {
-    var source: LMSource?
-    var name: String?
-    var avatar: String?
+public class LMPoster: Mappable {
+    public var source: LMSource?
+    public var name: String?
+    public var avatar: String?
     
-    required init?(_ map: Map) {}
+    public required init?(_ map: Map) {}
     
-    func mapping(map: Map) {
+    public func mapping(map: Map) {
         source <- map["source"]
         name   <- map["name"]
         avatar <- map["avatar"]

--- a/LocalMeasureWidgetKit/LMSource.swift
+++ b/LocalMeasureWidgetKit/LMSource.swift
@@ -8,14 +8,14 @@
 
 import ObjectMapper
 
-class LMSource: Mappable {
-    var link: String?
-    var network: String?
-    var id: String?
+public class LMSource: Mappable {
+    public var link: String?
+    public var network: String?
+    public var id: String?
     
-    required init?(_ map: Map) {}
+    public required init?(_ map: Map) {}
     
-    func mapping(map: Map) {
+    public func mapping(map: Map) {
         link    <- map["link"]
         network <- map["network"]
         id      <- map["id"]

--- a/LocalMeasureWidgetKit/LMWidget.swift
+++ b/LocalMeasureWidgetKit/LMWidget.swift
@@ -8,27 +8,27 @@
 
 import ObjectMapper
 
-class LMWidget: Mappable {
-    var background_time: String?
-    var hash: String?
-    var description: String?
-    var title: String?
-    var created_at: String?
-    var date_start: String?
-    var locations: [LMLocation]?
-    var is_frozen: Bool?
-    var post_time: String?
-    var limit: Int?
-    var no_load_more: Bool?
-    var order_by: String?
-    var no_branding: Bool?
-    var type: String?
-    var date_end: String?
-    var grid_size: String?
+public class LMWidget: Mappable {
+    public var background_time: String?
+    public var hash: String?
+    public var description: String?
+    public var title: String?
+    public var created_at: String?
+    public var date_start: String?
+    public var locations: [LMLocation]?
+    public var is_frozen: Bool?
+    public var post_time: String?
+    public var limit: Int?
+    public var no_load_more: Bool?
+    public var order_by: String?
+    public var no_branding: Bool?
+    public var type: String?
+    public var date_end: String?
+    public var grid_size: String?
     
-    required init?(_ map: Map) {}
+    public required init?(_ map: Map) {}
     
-    func mapping(map: Map) {
+    public func mapping(map: Map) {
         background_time <- map["background_time"]
         hash            <- map["hash"]
         description     <- map["description"]

--- a/LocalMeasureWidgetKit/LMWidgetKit.swift
+++ b/LocalMeasureWidgetKit/LMWidgetKit.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-class LMWidgetKit {
+public class LMWidgetKit {
     
-    func setup(userHash: String) {
+    public func setup(userHash: String) {
         do {
             try LMWidgetKitSetup.sharedInstance.setUserHash(userHash)
         } catch {

--- a/LocalMeasureWidgetKit/LMWidgetKitPostsExtension.swift
+++ b/LocalMeasureWidgetKit/LMWidgetKitPostsExtension.swift
@@ -11,7 +11,7 @@ import ObjectMapper
 
 extension LMWidgetKit {
     
-    func posts(widgetHash: String, completion: (posts: [LMPost]) -> Void) {
+    public func posts(widgetHash: String, completion: (posts: [LMPost]) -> Void) {
         if widgetHash.isEmpty {
             print("An empty widget hash was passed.")
             return completion( posts: [LMPost]() )

--- a/LocalMeasureWidgetKit/LMWidgetKitWidgetsExtension.swift
+++ b/LocalMeasureWidgetKit/LMWidgetKitWidgetsExtension.swift
@@ -11,7 +11,7 @@ import ObjectMapper
 
 extension LMWidgetKit {
     
-    func widgets(completion: (widgets: [LMWidget]) -> Void) {
+    public func widgets(completion: (widgets: [LMWidget]) -> Void) {
         do {
             let url = try "\(LMWidgetKitSetup.sharedInstance.getURL())/widgets.json"
             Alamofire.request(.GET, url).responseJSON { response in


### PR DESCRIPTION
- To be available to the end user, some classes (models and gateway extensions of the `LMWidgetKit` class) need to be exposed.
- Making the necessary classes public, as well as their attributes and methods where required.